### PR TITLE
Fix lint errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL=postgres://USER:PASS@localhost:5432/mydb
+JWT_SECRET=your-secret

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@
 $ npm install
 ```
 
+Create a `.env` file using the provided example and update the values for your
+database connection and JWT secret:
+
+```bash
+cp .env.example .env
+# edit .env with your settings
+```
+
 ## Compile and run the project
 
 ```bash

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,5 @@
 /* eslint-disable prettier/prettier */
 import { Module } from '@nestjs/common';
-import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
 
 import { TestController } from './test/test.controller';
@@ -10,8 +9,6 @@ import { AuthModule } from './auth/auth.module';
 import { EmpresasModule } from './empresas/empresas.module';
 import { UsuarioEmpresaModule } from './usuario-empresa/usuario-empresa.module';
 
-import { JwtAuthGuard } from './auth/auth.guard';
-import { RolesGuard } from './auth/roles.guard';
 
 @Module({
   controllers: [TestController],

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -18,7 +18,7 @@ import { RolesGuard } from './roles.guard';
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       imports: [ConfigModule],
-      useFactory: async (configService: ConfigService) => ({
+      useFactory: (configService: ConfigService) => ({
         secret: configService.getOrThrow<string>('JWT_SECRET'),
         signOptions: { expiresIn: '1d' },
       }),

--- a/src/common/logging/logger.config.ts
+++ b/src/common/logging/logger.config.ts
@@ -4,9 +4,7 @@ import { utilities as nestWinstonModuleUtilities } from 'nest-winston';
 import { WinstonModuleOptions } from 'nest-winston';
 import * as winston from 'winston';
 import 'winston-daily-rotate-file';
-import 'winston-loggly-bulk';
-
-const { Loggly } = require('winston-loggly-bulk');
+import { Loggly } from 'winston-loggly-bulk';
 
 
 export const loggerConfig: WinstonModuleOptions = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,4 +18,4 @@ async function bootstrap() {
   const logger = new Logger('Auren');
   logger.log(`✅ Backend corriendo en http://localhost:${port}`);
 }
-bootstrap();
+void bootstrap();

--- a/src/test/test.controller.ts
+++ b/src/test/test.controller.ts
@@ -1,12 +1,13 @@
 /* eslint-disable prettier/prettier */
 import { Controller, Get, UseGuards, Req } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/auth.guard';
+import { Request } from 'express';
 
 @Controller('test')
 export class TestController {
   @Get()
   @UseGuards(JwtAuthGuard)
-  test(@Req() req: any) {
+  test(@Req() req: Request & { user?: unknown }) {
     console.log('✅ TestController - Usuario:', req.user);
     return {
       message: 'Ruta protegida accedida correctamente',


### PR DESCRIPTION
## Summary
- remove unused guard imports in `AppModule`
- simplify auth module factory
- use ES import for Loggly
- mark bootstrap call as ignored promise
- tighten request typing in test controller

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68524ccf15308320beffc6e043df58b0